### PR TITLE
Port SDK from turso-cli

### DIFF
--- a/apiTokens.go
+++ b/apiTokens.go
@@ -15,8 +15,8 @@ type ApiToken struct {
 
 type ApiTokensClient client
 
-func (a *ApiTokensClient) List(ctx context.Context) ([]ApiToken, error) {
-	res, err := a.client.Get(ctx, "/v1/auth/api-tokens", nil)
+func (c *ApiTokensClient) List(ctx context.Context) ([]ApiToken, error) {
+	res, err := c.client.Get(ctx, "/v1/auth/api-tokens", nil)
 	if err != nil {
 		return []ApiToken{}, fmt.Errorf("failed to get api tokens list: %s", err)
 	}
@@ -39,10 +39,10 @@ type CreateApiToken struct {
 	Value string `json:"value"`
 }
 
-func (a *ApiTokensClient) Create(ctx context.Context, name string) (CreateApiToken, error) {
+func (c *ApiTokensClient) Create(ctx context.Context, name string) (CreateApiToken, error) {
 	url := fmt.Sprintf("/v2/auth/api-tokens/%s", name)
 
-	res, err := a.client.Post(ctx, url, nil)
+	res, err := c.client.Post(ctx, url, nil)
 	if err != nil {
 		return CreateApiToken{}, fmt.Errorf("failed to create token: %s", err)
 	}
@@ -64,10 +64,10 @@ func (a *ApiTokensClient) Create(ctx context.Context, name string) (CreateApiTok
 	return data.ApiToken, nil
 }
 
-func (a *ApiTokensClient) Revoke(ctx context.Context, name string) error {
+func (c *ApiTokensClient) Revoke(ctx context.Context, name string) error {
 	url := fmt.Sprintf("/v1/auth/api-tokens/%s", name)
 
-	res, err := a.client.Delete(ctx, url, nil)
+	res, err := c.client.Delete(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to revoke API token: %s", err)
 	}

--- a/apiTokens.go
+++ b/apiTokens.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -14,8 +15,8 @@ type ApiToken struct {
 
 type ApiTokensClient client
 
-func (a *ApiTokensClient) List() ([]ApiToken, error) {
-	res, err := a.client.Get("/v1/auth/api-tokens", nil)
+func (a *ApiTokensClient) List(ctx context.Context) ([]ApiToken, error) {
+	res, err := a.client.Get(ctx, "/v1/auth/api-tokens", nil)
 	if err != nil {
 		return []ApiToken{}, fmt.Errorf("failed to get api tokens list: %s", err)
 	}
@@ -38,10 +39,10 @@ type CreateApiToken struct {
 	Value string `json:"value"`
 }
 
-func (a *ApiTokensClient) Create(name string) (CreateApiToken, error) {
+func (a *ApiTokensClient) Create(ctx context.Context, name string) (CreateApiToken, error) {
 	url := fmt.Sprintf("/v2/auth/api-tokens/%s", name)
 
-	res, err := a.client.Post(url, nil)
+	res, err := a.client.Post(ctx, url, nil)
 	if err != nil {
 		return CreateApiToken{}, fmt.Errorf("failed to create token: %s", err)
 	}
@@ -63,10 +64,10 @@ func (a *ApiTokensClient) Create(name string) (CreateApiToken, error) {
 	return data.ApiToken, nil
 }
 
-func (a *ApiTokensClient) Revoke(name string) error {
+func (a *ApiTokensClient) Revoke(ctx context.Context, name string) error {
 	url := fmt.Sprintf("/v1/auth/api-tokens/%s", name)
 
-	res, err := a.client.Delete(url, nil)
+	res, err := a.client.Delete(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to revoke API token: %s", err)
 	}

--- a/apiTokens.go
+++ b/apiTokens.go
@@ -1,0 +1,80 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type ApiToken struct {
+	ID     string `json:"dbId"`
+	Name   string
+	Owner  uint
+	PubKey []byte
+}
+
+type ApiTokensClient client
+
+func (a *ApiTokensClient) List() ([]ApiToken, error) {
+	res, err := a.client.Get("/v1/auth/api-tokens", nil)
+	if err != nil {
+		return []ApiToken{}, fmt.Errorf("failed to get api tokens list: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get api tokens list: %s", res.Status)
+	}
+
+	type ListResponse struct {
+		ApiTokens []ApiToken `json:"tokens"`
+	}
+	resp, err := unmarshal[ListResponse](res)
+	return resp.ApiTokens, err
+}
+
+type CreateApiToken struct {
+	Name  string `json:"name"`
+	ID    string `json:"id"`
+	Value string `json:"value"`
+}
+
+func (a *ApiTokensClient) Create(name string) (CreateApiToken, error) {
+	url := fmt.Sprintf("/v2/auth/api-tokens/%s", name)
+
+	res, err := a.client.Post(url, nil)
+	if err != nil {
+		return CreateApiToken{}, fmt.Errorf("failed to create token: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return CreateApiToken{}, parseResponseError(res)
+	}
+
+	type CreateApiTokenResponse struct {
+		ApiToken CreateApiToken `json:"token"`
+	}
+
+	data, err := unmarshal[CreateApiTokenResponse](res)
+	if err != nil {
+		return CreateApiToken{}, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	return data.ApiToken, nil
+}
+
+func (a *ApiTokensClient) Revoke(name string) error {
+	url := fmt.Sprintf("/v1/auth/api-tokens/%s", name)
+
+	res, err := a.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to revoke API token: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+
+	return nil
+}

--- a/billing.go
+++ b/billing.go
@@ -1,0 +1,175 @@
+package turso
+
+import (
+	"fmt"
+	"io"
+)
+
+type BillingClient client
+
+type Portal struct {
+	URL string `json:"url"`
+}
+
+func (c *BillingClient) Portal() (Portal, error) {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+
+	r, err := c.client.Post(prefix+"/billing/portal", nil)
+	if err != nil {
+		return Portal{}, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return Portal{}, fmt.Errorf("failed to get billing portal with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Portal Portal }](r)
+	return resp.Portal, err
+}
+
+func (c *BillingClient) PortalForStripeId(stripeId string) (Portal, error) {
+	prefix := "/v1"
+	type Body struct {
+		StripeID string `json:"stripe_id"`
+	}
+	var body io.Reader
+	var err error
+	body, err = marshal(Body{StripeID: stripeId})
+	if err != nil {
+		return Portal{}, fmt.Errorf("could not serialize request body: %w", err)
+	}
+	r, err := c.client.Post(prefix+"/billing/portal", body)
+	if err != nil {
+		return Portal{}, fmt.Errorf("failed to get portal: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return Portal{}, fmt.Errorf("failed to get billing portal with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Portal Portal }](r)
+	return resp.Portal, err
+}
+
+func (c *BillingClient) HasPaymentMethod() (bool, error) {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+	r, err := c.client.Get(prefix+"/billing/payment-methods", nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return false, fmt.Errorf("failed to check payment method with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Exists bool }](r)
+	return resp.Exists, err
+}
+
+func (c *BillingClient) HasPaymentMethodWithStripeId(stripeId string) (bool, error) {
+	prefix := "/v1"
+	r, err := c.client.Get(fmt.Sprintf("%s/billing/payment-methods?stripe_id=%s", prefix, stripeId), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to check payment method: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return false, fmt.Errorf("failed to check payment method with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Exists bool }](r)
+	return resp.Exists, err
+}
+
+func (c *BillingClient) CreateStripeCustomer(name string) (string, error) {
+	prefix := "/v1"
+	type Body struct{ Name string }
+	body, err := marshal(Body{name})
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := c.client.Post(prefix+"/organizations/stripe-customer", body)
+	if err != nil {
+		return "", fmt.Errorf("failed to create stripe customer: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return "", fmt.Errorf("failed to create stripe customer with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ StripeCustomerId string }](r)
+	return resp.StripeCustomerId, err
+}
+
+type BillingAddress struct {
+	Line1      string `json:"line1"`
+	Line2      string `json:"line2"`
+	City       string `json:"city"`
+	State      string `json:"state"`
+	PostalCode string `json:"postal_code"`
+	Country    string `json:"country"`
+}
+
+type TaxID struct {
+	Value   string `json:"value"`
+	Country string `json:"country"`
+}
+type BillingCustomer struct {
+	Name           string         `json:"name"`
+	Email          string         `json:"email"`
+	TaxID          TaxID          `json:"tax_id"`
+	BillingAddress BillingAddress `json:"billing_address"`
+}
+
+func (c *BillingClient) GetBillingCustomer() (BillingCustomer, error) {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+	r, err := c.client.Get(prefix+"/billing/customer", nil)
+	if err != nil {
+		return BillingCustomer{}, fmt.Errorf("failed to get billing customer: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return BillingCustomer{}, fmt.Errorf("failed to get billing customer with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[BillingCustomer](r)
+	return resp, err
+}
+
+func (c *BillingClient) UpdateBillingCustomer(customer BillingCustomer) error {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+	body, err := marshal(customer)
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+	r, err := c.client.Put(prefix+"/billing/customer", body)
+	if err != nil {
+		return fmt.Errorf("failed to update billing customer: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return fmt.Errorf("failed to update billing customer with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	return nil
+}

--- a/billing.go
+++ b/billing.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -11,13 +12,13 @@ type Portal struct {
 	URL string `json:"url"`
 }
 
-func (c *BillingClient) Portal() (Portal, error) {
+func (c *BillingClient) Portal(ctx context.Context) (Portal, error) {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
 	}
 
-	r, err := c.client.Post(prefix+"/billing/portal", nil)
+	r, err := c.client.Post(ctx, prefix+"/billing/portal", nil)
 	if err != nil {
 		return Portal{}, fmt.Errorf("failed to get database usage: %w", err)
 	}
@@ -31,7 +32,7 @@ func (c *BillingClient) Portal() (Portal, error) {
 	return resp.Portal, err
 }
 
-func (c *BillingClient) PortalForStripeId(stripeId string) (Portal, error) {
+func (c *BillingClient) PortalForStripeId(ctx context.Context, stripeId string) (Portal, error) {
 	prefix := "/v1"
 	type Body struct {
 		StripeID string `json:"stripe_id"`
@@ -42,7 +43,7 @@ func (c *BillingClient) PortalForStripeId(stripeId string) (Portal, error) {
 	if err != nil {
 		return Portal{}, fmt.Errorf("could not serialize request body: %w", err)
 	}
-	r, err := c.client.Post(prefix+"/billing/portal", body)
+	r, err := c.client.Post(ctx, prefix+"/billing/portal", body)
 	if err != nil {
 		return Portal{}, fmt.Errorf("failed to get portal: %w", err)
 	}
@@ -56,12 +57,12 @@ func (c *BillingClient) PortalForStripeId(stripeId string) (Portal, error) {
 	return resp.Portal, err
 }
 
-func (c *BillingClient) HasPaymentMethod() (bool, error) {
+func (c *BillingClient) HasPaymentMethod(ctx context.Context) (bool, error) {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
 	}
-	r, err := c.client.Get(prefix+"/billing/payment-methods", nil)
+	r, err := c.client.Get(ctx, prefix+"/billing/payment-methods", nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to get database usage: %w", err)
 	}
@@ -75,9 +76,9 @@ func (c *BillingClient) HasPaymentMethod() (bool, error) {
 	return resp.Exists, err
 }
 
-func (c *BillingClient) HasPaymentMethodWithStripeId(stripeId string) (bool, error) {
+func (c *BillingClient) HasPaymentMethodWithStripeId(ctx context.Context, stripeId string) (bool, error) {
 	prefix := "/v1"
-	r, err := c.client.Get(fmt.Sprintf("%s/billing/payment-methods?stripe_id=%s", prefix, stripeId), nil)
+	r, err := c.client.Get(ctx, fmt.Sprintf("%s/billing/payment-methods?stripe_id=%s", prefix, stripeId), nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to check payment method: %w", err)
 	}
@@ -91,7 +92,7 @@ func (c *BillingClient) HasPaymentMethodWithStripeId(stripeId string) (bool, err
 	return resp.Exists, err
 }
 
-func (c *BillingClient) CreateStripeCustomer(name string) (string, error) {
+func (c *BillingClient) CreateStripeCustomer(ctx context.Context, name string) (string, error) {
 	prefix := "/v1"
 	type Body struct{ Name string }
 	body, err := marshal(Body{name})
@@ -99,7 +100,7 @@ func (c *BillingClient) CreateStripeCustomer(name string) (string, error) {
 		return "", fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	r, err := c.client.Post(prefix+"/organizations/stripe-customer", body)
+	r, err := c.client.Post(ctx, prefix+"/organizations/stripe-customer", body)
 	if err != nil {
 		return "", fmt.Errorf("failed to create stripe customer: %w", err)
 	}
@@ -133,12 +134,12 @@ type BillingCustomer struct {
 	BillingAddress BillingAddress `json:"billing_address"`
 }
 
-func (c *BillingClient) GetBillingCustomer() (BillingCustomer, error) {
+func (c *BillingClient) GetBillingCustomer(ctx context.Context) (BillingCustomer, error) {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
 	}
-	r, err := c.client.Get(prefix+"/billing/customer", nil)
+	r, err := c.client.Get(ctx, prefix+"/billing/customer", nil)
 	if err != nil {
 		return BillingCustomer{}, fmt.Errorf("failed to get billing customer: %w", err)
 	}
@@ -152,7 +153,7 @@ func (c *BillingClient) GetBillingCustomer() (BillingCustomer, error) {
 	return resp, err
 }
 
-func (c *BillingClient) UpdateBillingCustomer(customer BillingCustomer) error {
+func (c *BillingClient) UpdateBillingCustomer(ctx context.Context, customer BillingCustomer) error {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
@@ -161,7 +162,7 @@ func (c *BillingClient) UpdateBillingCustomer(customer BillingCustomer) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
-	r, err := c.client.Put(prefix+"/billing/customer", body)
+	r, err := c.client.Put(ctx, prefix+"/billing/customer", body)
 	if err != nil {
 		return fmt.Errorf("failed to update billing customer: %w", err)
 	}

--- a/client.go
+++ b/client.go
@@ -81,8 +81,8 @@ func (o *withHTTPClient) apply(client *Client) {
 	client.httpClient = o.httpClient
 }
 
-func (t *Client) newRequest(ctx context.Context, method, urlPath string, body io.Reader) (*http.Request, error) {
-	url, err := url.Parse(t.baseUrl.String())
+func (c *Client) newRequest(ctx context.Context, method, urlPath string, body io.Reader) (*http.Request, error) {
+	url, err := url.Parse(c.baseUrl.String())
 	if err != nil {
 		return nil, err
 	}
@@ -94,47 +94,47 @@ func (t *Client) newRequest(ctx context.Context, method, urlPath string, body io
 	if err != nil {
 		return nil, err
 	}
-	if t.token != "" {
-		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
+	if c.token != "" {
+		req.Header.Add("Authorization", fmt.Sprint("Bearer ", c.token))
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("turso-go/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH))
 	req.Header.Add("Content-Type", "application/json")
 	return req, nil
 }
 
-func (t *Client) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
-	req, err := t.newRequest(ctx, method, path, body)
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := c.newRequest(ctx, method, path, body)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := t.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (t *Client) Get(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
-	return t.do(ctx, "GET", path, body)
+func (c *Client) Get(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, "GET", path, body)
 }
 
-func (t *Client) Post(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
-	return t.do(ctx, "POST", path, body)
+func (c *Client) Post(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, "POST", path, body)
 }
 
-func (t *Client) Patch(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
-	return t.do(ctx, "PATCH", path, body)
+func (c *Client) Patch(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, "PATCH", path, body)
 }
 
-func (t *Client) Put(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
-	return t.do(ctx, "PUT", path, body)
+func (c *Client) Put(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, "PUT", path, body)
 }
 
-func (t *Client) Delete(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
-	return t.do(ctx, "DELETE", path, body)
+func (c *Client) Delete(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, "DELETE", path, body)
 }
 
-func (t *Client) Upload(ctx context.Context, path string, fileData *os.File) (*http.Response, error) {
+func (c *Client) Upload(ctx context.Context, path string, fileData *os.File) (*http.Response, error) {
 	body, bodyWriter := io.Pipe()
 	writer := multipart.NewWriter(bodyWriter)
 	go func() {
@@ -149,14 +149,25 @@ func (t *Client) Upload(ctx context.Context, path string, fileData *os.File) (*h
 		}
 		bodyWriter.CloseWithError(writer.Close())
 	}()
-	req, err := t.newRequest(ctx, "POST", path, body)
+	req, err := c.newRequest(ctx, "POST", path, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	resp, err := t.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (c *Client) isNotMemberErr(status int) bool {
+	if status == http.StatusForbidden && c.Org != "" {
+		return true
+	}
+	return false
+}
+
+func (c *Client) notMemberErr() error {
+	return fmt.Errorf("not a member of organization %s", c.Org)
 }

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -80,7 +81,7 @@ func (o *withHTTPClient) apply(client *Client) {
 	client.httpClient = o.httpClient
 }
 
-func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Request, error) {
+func (t *Client) newRequest(ctx context.Context, method, urlPath string, body io.Reader) (*http.Request, error) {
 	url, err := url.Parse(t.baseUrl.String())
 	if err != nil {
 		return nil, err
@@ -89,7 +90,7 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(method, url.String(), body)
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +102,8 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 	return req, nil
 }
 
-func (t *Client) do(method, path string, body io.Reader) (*http.Response, error) {
-	req, err := t.newRequest(method, path, body)
+func (t *Client) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := t.newRequest(ctx, method, path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -113,27 +114,27 @@ func (t *Client) do(method, path string, body io.Reader) (*http.Response, error)
 	return resp, nil
 }
 
-func (t *Client) Get(path string, body io.Reader) (*http.Response, error) {
-	return t.do("GET", path, body)
+func (t *Client) Get(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return t.do(ctx, "GET", path, body)
 }
 
-func (t *Client) Post(path string, body io.Reader) (*http.Response, error) {
-	return t.do("POST", path, body)
+func (t *Client) Post(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return t.do(ctx, "POST", path, body)
 }
 
-func (t *Client) Patch(path string, body io.Reader) (*http.Response, error) {
-	return t.do("PATCH", path, body)
+func (t *Client) Patch(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return t.do(ctx, "PATCH", path, body)
 }
 
-func (t *Client) Put(path string, body io.Reader) (*http.Response, error) {
-	return t.do("PUT", path, body)
+func (t *Client) Put(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return t.do(ctx, "PUT", path, body)
 }
 
-func (t *Client) Delete(path string, body io.Reader) (*http.Response, error) {
-	return t.do("DELETE", path, body)
+func (t *Client) Delete(ctx context.Context, path string, body io.Reader) (*http.Response, error) {
+	return t.do(ctx, "DELETE", path, body)
 }
 
-func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) {
+func (t *Client) Upload(ctx context.Context, path string, fileData *os.File) (*http.Response, error) {
 	body, bodyWriter := io.Pipe()
 	writer := multipart.NewWriter(bodyWriter)
 	go func() {
@@ -148,7 +149,7 @@ func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) 
 		}
 		bodyWriter.CloseWithError(writer.Close())
 	}()
-	req, err := t.newRequest("POST", path, body)
+	req, err := t.newRequest(ctx, "POST", path, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -1,0 +1,140 @@
+package turso
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+)
+
+// Collection of all turso clients
+type Client struct {
+	baseUrl *url.URL
+	token   string
+	Org     string
+
+	// Single instance to be reused by all clients
+	base *client
+
+	Instances     *InstancesClient
+	Databases     *DatabasesClient
+	Feedback      *FeedbackClient
+	Organizations *OrganizationsClient
+	ApiTokens     *ApiTokensClient
+	Locations     *LocationsClient
+	Tokens        *TokensClient
+	Users         *UsersClient
+	Plans         *PlansClient
+	Subscriptions *SubscriptionClient
+	Billing       *BillingClient
+	Groups        *GroupsClient
+	Invoices      *InvoicesClient
+}
+
+// Client struct that will be aliases by all other clients
+type client struct {
+	client *Client
+}
+
+func New(base *url.URL, token string, org string) *Client {
+	c := &Client{baseUrl: base, token: token, Org: org}
+
+	c.base = &client{c}
+	c.Instances = (*InstancesClient)(c.base)
+	c.Databases = (*DatabasesClient)(c.base)
+	c.Feedback = (*FeedbackClient)(c.base)
+	c.Organizations = (*OrganizationsClient)(c.base)
+	c.ApiTokens = (*ApiTokensClient)(c.base)
+	c.Locations = (*LocationsClient)(c.base)
+	c.Tokens = (*TokensClient)(c.base)
+	c.Users = (*UsersClient)(c.base)
+	c.Plans = (*PlansClient)(c.base)
+	c.Subscriptions = (*SubscriptionClient)(c.base)
+	c.Billing = (*BillingClient)(c.base)
+	c.Groups = (*GroupsClient)(c.base)
+	c.Invoices = (*InvoicesClient)(c.base)
+	return c
+}
+
+func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Request, error) {
+	url, err := url.Parse(t.baseUrl.String())
+	if err != nil {
+		return nil, err
+	}
+	url, err = url.Parse(urlPath)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if t.token != "" {
+		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
+	}
+	req.Header.Add("User-Agent", fmt.Sprintf("turso-go/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH))
+	req.Header.Add("Content-Type", "application/json")
+	return req, nil
+}
+
+func (t *Client) do(method, path string, body io.Reader) (*http.Response, error) {
+	req, err := t.newRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (t *Client) Get(path string, body io.Reader) (*http.Response, error) {
+	return t.do("GET", path, body)
+}
+
+func (t *Client) Post(path string, body io.Reader) (*http.Response, error) {
+	return t.do("POST", path, body)
+}
+
+func (t *Client) Patch(path string, body io.Reader) (*http.Response, error) {
+	return t.do("PATCH", path, body)
+}
+
+func (t *Client) Put(path string, body io.Reader) (*http.Response, error) {
+	return t.do("PUT", path, body)
+}
+
+func (t *Client) Delete(path string, body io.Reader) (*http.Response, error) {
+	return t.do("DELETE", path, body)
+}
+
+func (t *Client) Upload(path string, fileData *os.File) (*http.Response, error) {
+	body, bodyWriter := io.Pipe()
+	writer := multipart.NewWriter(bodyWriter)
+	go func() {
+		formFile, err := writer.CreateFormFile("file", fileData.Name())
+		if err != nil {
+			bodyWriter.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(formFile, fileData); err != nil {
+			bodyWriter.CloseWithError(err)
+			return
+		}
+		bodyWriter.CloseWithError(writer.Close())
+	}()
+	req, err := t.newRequest("POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/databases.go
+++ b/databases.go
@@ -1,0 +1,431 @@
+package turso
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Database struct {
+	ID            string `json:"dbId" mapstructure:"dbId"`
+	Name          string
+	Regions       []string
+	PrimaryRegion string
+	Hostname      string
+	Version       string
+	Group         string
+	Sleeping      bool
+}
+
+type DatabasesClient client
+
+func (d *DatabasesClient) List() ([]Database, error) {
+	r, err := d.client.Get(d.URL(""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database listing: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get database listing: %w", parseResponseError(r))
+	}
+
+	type ListResponse struct {
+		Databases []Database `json:"databases"`
+	}
+	resp, err := unmarshal[ListResponse](r)
+	return resp.Databases, err
+}
+
+func (d *DatabasesClient) Delete(database string) error {
+	url := d.URL("/" + database)
+	r, err := d.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete database: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("database %s not found", database)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete database: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+type CreateDatabaseResponse struct {
+	Database Database
+	Username string
+}
+
+type DBSeed struct {
+	Type      string     `json:"type"`
+	Name      string     `json:"value,omitempty"`
+	URL       string     `json:"url,omitempty"`
+	Timestamp *time.Time `json:"timestamp,omitempty"`
+}
+
+type CreateDatabaseBody struct {
+	Name       string  `json:"name"`
+	Location   string  `json:"location"`
+	Image      string  `json:"image,omitempty"`
+	Extensions string  `json:"extensions,omitempty"`
+	Group      string  `json:"group,omitempty"`
+	Seed       *DBSeed `json:"seed,omitempty"`
+	Schema     string  `json:"schema,omitempty"`
+	IsSchema   bool    `json:"is_schema,omitempty"`
+}
+
+func (d *DatabasesClient) Create(name, location, image, extensions, group string, schema string, isSchema bool, seed *DBSeed) (*CreateDatabaseResponse, error) {
+	params := CreateDatabaseBody{name, location, image, extensions, group, seed, schema, isSchema}
+
+	body, err := marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	res, err := d.client.Post(d.URL(""), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if res.StatusCode == http.StatusUnprocessableEntity {
+		return nil, fmt.Errorf("database name '%s' is not available", name)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseResponseError(res)
+	}
+
+	data, err := unmarshal[*CreateDatabaseResponse](res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	return data, nil
+}
+
+func (d *DatabasesClient) Seed(name string, dbFile *os.File) error {
+	url := d.URL(fmt.Sprintf("/%s/seed", name))
+	res, err := d.client.Upload(url, dbFile)
+	if err != nil {
+		return fmt.Errorf("failed to create database: %w", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("database name '%s' is not available", name)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *DatabasesClient) UploadDump(dbFile *os.File) (string, error) {
+	url := d.URL("/dumps")
+	res, err := d.client.Upload(url, dbFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload the dump file: %w", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return "", notMemberErr(org)
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", parseResponseError(res)
+	}
+	type response struct {
+		DumpURL string `json:"dump_url"`
+	}
+	data, err := unmarshal[response](res)
+	if err != nil {
+		return "", err
+	}
+	return data.DumpURL, nil
+}
+
+type DatabaseTokenRequest struct {
+	Permissions *PermissionsClaim `json:"permissions,omitempty"`
+}
+
+func (d *DatabasesClient) Token(database string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
+	authorization := ""
+	if readOnly {
+		authorization = "&authorization=read-only"
+	}
+	url := d.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", database, expiration, authorization))
+
+	req := DatabaseTokenRequest{permissions}
+	body, err := marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := d.client.Post(url, body)
+	if err != nil {
+		return "", fmt.Errorf("failed to get database token: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return "", notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get database token: %w", parseResponseError(r))
+	}
+
+	type JwtResponse struct{ Jwt string }
+	data, err := unmarshal[JwtResponse](r)
+	if err != nil {
+		return "", err
+	}
+	return data.Jwt, nil
+}
+
+func (d *DatabasesClient) Rotate(database string) error {
+	url := d.URL(fmt.Sprintf("/%s/auth/rotate", database))
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to rotate database keys: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to rotate database keys: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (d *DatabasesClient) Update(database string, group bool) error {
+	url := d.URL(fmt.Sprintf("/%s/update", database))
+	if group {
+		url += "?group=true"
+	}
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to update database: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update database: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+type Stats struct {
+	TopQueries []struct {
+		Query       string `json:"query"`
+		RowsRead    int    `json:"rows_read"`
+		RowsWritten int    `json:"rows_written"`
+	} `json:"top_queries,omitempty"`
+}
+
+func (d *DatabasesClient) Stats(database string) (Stats, error) {
+	url := d.URL(fmt.Sprintf("/%s/stats", database))
+	r, err := d.client.Get(url, nil)
+	if err != nil {
+		return Stats{}, fmt.Errorf("failed to update database: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return Stats{}, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return Stats{}, fmt.Errorf("failed to get stats for database: %w", parseResponseError(r))
+	}
+
+	return unmarshal[Stats](r)
+}
+
+type Body struct {
+	Org string `json:"org"`
+}
+
+func (d *DatabasesClient) Transfer(database, org string) error {
+	url := d.URL(fmt.Sprintf("/%s/transfer", database))
+	body, err := json.Marshal(Body{Org: org})
+	bodyReader := bytes.NewReader(body)
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+	r, err := d.client.Post(url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to transfer database")
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to transfer %s database to org %s: %w", database, org, parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (d *DatabasesClient) Wakeup(database string) error {
+	url := d.URL(fmt.Sprintf("/%s/wakeup", database))
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to wakeup database: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to wakeup database: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+type Usage struct {
+	RowsRead         uint64 `json:"rows_read,omitempty"`
+	RowsWritten      uint64 `json:"rows_written,omitempty"`
+	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+	BytesSynced      uint64 `json:"bytes_synced,omitempty"`
+}
+
+type InstanceUsage struct {
+	UUID  string `json:"uuid,omitempty"`
+	Usage Usage  `json:"usage"`
+}
+
+type DbUsage struct {
+	UUID      string          `json:"uuid,omitempty"`
+	Instances []InstanceUsage `json:"instances"`
+	Usage     Usage           `json:"usage"`
+}
+
+type DbUsageResponse struct {
+	DbUsage DbUsage `json:"database"`
+}
+
+func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
+	url := d.URL(fmt.Sprintf("/%s/usage", database))
+
+	r, err := d.client.Get(url, nil)
+	if err != nil {
+		return DbUsage{}, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return DbUsage{}, fmt.Errorf("failed to get database usage: %w", parseResponseError(r))
+	}
+
+	body, err := unmarshal[DbUsageResponse](r)
+	if err != nil {
+		return DbUsage{}, err
+	}
+	return body.DbUsage, nil
+}
+
+func (d *DatabasesClient) URL(suffix string) string {
+	prefix := "/v1"
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
+	}
+	return prefix + "/databases" + suffix
+}
+
+type DatabaseConfig struct {
+	AllowAttach bool `json:"allow_attach"`
+}
+
+func (d *DatabasesClient) GetConfig(database string) (DatabaseConfig, error) {
+	url := d.URL(fmt.Sprintf("/%s/configuration", database))
+	r, err := d.client.Get(url, nil)
+	if err != nil {
+		return DatabaseConfig{}, fmt.Errorf("failed to get database: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return DatabaseConfig{}, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		err = parseResponseError(r)
+		return DatabaseConfig{}, fmt.Errorf("failed to get config for database: %d %s", r.StatusCode, err)
+	}
+
+	return unmarshal[DatabaseConfig](r)
+}
+
+func (d *DatabasesClient) UpdateConfig(database string, config DatabaseConfig) error {
+	url := d.URL(fmt.Sprintf("/%s/configuration", database))
+	body, err := marshal(config)
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+	r, err := d.client.Patch(url, body)
+	if err != nil {
+		return fmt.Errorf("failed to update database: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		err = parseResponseError(r)
+		return fmt.Errorf("failed to update config for database: %d %s", r.StatusCode, err)
+	}
+
+	return nil
+}

--- a/databases.go
+++ b/databases.go
@@ -2,6 +2,7 @@ package turso
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,8 +23,8 @@ type Database struct {
 
 type DatabasesClient client
 
-func (d *DatabasesClient) List() ([]Database, error) {
-	r, err := d.client.Get(d.URL(""), nil)
+func (d *DatabasesClient) List(ctx context.Context) ([]Database, error) {
+	r, err := d.client.Get(ctx, d.URL(""), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database listing: %s", err)
 	}
@@ -45,9 +46,9 @@ func (d *DatabasesClient) List() ([]Database, error) {
 	return resp.Databases, err
 }
 
-func (d *DatabasesClient) Delete(database string) error {
+func (d *DatabasesClient) Delete(ctx context.Context, database string) error {
 	url := d.URL("/" + database)
-	r, err := d.client.Delete(url, nil)
+	r, err := d.client.Delete(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete database: %s", err)
 	}
@@ -92,7 +93,7 @@ type CreateDatabaseBody struct {
 	IsSchema   bool    `json:"is_schema,omitempty"`
 }
 
-func (d *DatabasesClient) Create(name, location, image, extensions, group string, schema string, isSchema bool, seed *DBSeed) (*CreateDatabaseResponse, error) {
+func (d *DatabasesClient) Create(ctx context.Context, name, location, image, extensions, group string, schema string, isSchema bool, seed *DBSeed) (*CreateDatabaseResponse, error) {
 	params := CreateDatabaseBody{name, location, image, extensions, group, seed, schema, isSchema}
 
 	body, err := marshal(params)
@@ -100,7 +101,7 @@ func (d *DatabasesClient) Create(name, location, image, extensions, group string
 		return nil, fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	res, err := d.client.Post(d.URL(""), body)
+	res, err := d.client.Post(ctx, d.URL(""), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database: %s", err)
 	}
@@ -127,9 +128,9 @@ func (d *DatabasesClient) Create(name, location, image, extensions, group string
 	return data, nil
 }
 
-func (d *DatabasesClient) Seed(name string, dbFile *os.File) error {
+func (d *DatabasesClient) Seed(ctx context.Context, name string, dbFile *os.File) error {
 	url := d.URL(fmt.Sprintf("/%s/seed", name))
-	res, err := d.client.Upload(url, dbFile)
+	res, err := d.client.Upload(ctx, url, dbFile)
 	if err != nil {
 		return fmt.Errorf("failed to create database: %w", err)
 	}
@@ -150,9 +151,9 @@ func (d *DatabasesClient) Seed(name string, dbFile *os.File) error {
 	return nil
 }
 
-func (d *DatabasesClient) UploadDump(dbFile *os.File) (string, error) {
+func (d *DatabasesClient) UploadDump(ctx context.Context, dbFile *os.File) (string, error) {
 	url := d.URL("/dumps")
-	res, err := d.client.Upload(url, dbFile)
+	res, err := d.client.Upload(ctx, url, dbFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to upload the dump file: %w", err)
 	}
@@ -179,7 +180,7 @@ type DatabaseTokenRequest struct {
 	Permissions *PermissionsClaim `json:"permissions,omitempty"`
 }
 
-func (d *DatabasesClient) Token(database string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
+func (d *DatabasesClient) Token(ctx context.Context, database string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
 	authorization := ""
 	if readOnly {
 		authorization = "&authorization=read-only"
@@ -192,7 +193,7 @@ func (d *DatabasesClient) Token(database string, expiration string, readOnly boo
 		return "", fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	r, err := d.client.Post(url, body)
+	r, err := d.client.Post(ctx, url, body)
 	if err != nil {
 		return "", fmt.Errorf("failed to get database token: %w", err)
 	}
@@ -215,9 +216,9 @@ func (d *DatabasesClient) Token(database string, expiration string, readOnly boo
 	return data.Jwt, nil
 }
 
-func (d *DatabasesClient) Rotate(database string) error {
+func (d *DatabasesClient) Rotate(ctx context.Context, database string) error {
 	url := d.URL(fmt.Sprintf("/%s/auth/rotate", database))
-	r, err := d.client.Post(url, nil)
+	r, err := d.client.Post(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to rotate database keys: %w", err)
 	}
@@ -235,12 +236,12 @@ func (d *DatabasesClient) Rotate(database string) error {
 	return nil
 }
 
-func (d *DatabasesClient) Update(database string, group bool) error {
+func (d *DatabasesClient) Update(ctx context.Context, database string, group bool) error {
 	url := d.URL(fmt.Sprintf("/%s/update", database))
 	if group {
 		url += "?group=true"
 	}
-	r, err := d.client.Post(url, nil)
+	r, err := d.client.Post(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to update database: %w", err)
 	}
@@ -266,9 +267,9 @@ type Stats struct {
 	} `json:"top_queries,omitempty"`
 }
 
-func (d *DatabasesClient) Stats(database string) (Stats, error) {
+func (d *DatabasesClient) Stats(ctx context.Context, database string) (Stats, error) {
 	url := d.URL(fmt.Sprintf("/%s/stats", database))
-	r, err := d.client.Get(url, nil)
+	r, err := d.client.Get(ctx, url, nil)
 	if err != nil {
 		return Stats{}, fmt.Errorf("failed to update database: %w", err)
 	}
@@ -290,14 +291,14 @@ type Body struct {
 	Org string `json:"org"`
 }
 
-func (d *DatabasesClient) Transfer(database, org string) error {
+func (d *DatabasesClient) Transfer(ctx context.Context, database, org string) error {
 	url := d.URL(fmt.Sprintf("/%s/transfer", database))
 	body, err := json.Marshal(Body{Org: org})
 	bodyReader := bytes.NewReader(body)
 	if err != nil {
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
-	r, err := d.client.Post(url, bodyReader)
+	r, err := d.client.Post(ctx, url, bodyReader)
 	if err != nil {
 		return fmt.Errorf("failed to transfer database")
 	}
@@ -310,9 +311,9 @@ func (d *DatabasesClient) Transfer(database, org string) error {
 	return nil
 }
 
-func (d *DatabasesClient) Wakeup(database string) error {
+func (d *DatabasesClient) Wakeup(ctx context.Context, database string) error {
 	url := d.URL(fmt.Sprintf("/%s/wakeup", database))
-	r, err := d.client.Post(url, nil)
+	r, err := d.client.Post(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to wakeup database: %w", err)
 	}
@@ -352,10 +353,10 @@ type DbUsageResponse struct {
 	DbUsage DbUsage `json:"database"`
 }
 
-func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
+func (d *DatabasesClient) Usage(ctx context.Context, database string) (DbUsage, error) {
 	url := d.URL(fmt.Sprintf("/%s/usage", database))
 
-	r, err := d.client.Get(url, nil)
+	r, err := d.client.Get(ctx, url, nil)
 	if err != nil {
 		return DbUsage{}, fmt.Errorf("failed to get database usage: %w", err)
 	}
@@ -384,9 +385,9 @@ type DatabaseConfig struct {
 	AllowAttach bool `json:"allow_attach"`
 }
 
-func (d *DatabasesClient) GetConfig(database string) (DatabaseConfig, error) {
+func (d *DatabasesClient) GetConfig(ctx context.Context, database string) (DatabaseConfig, error) {
 	url := d.URL(fmt.Sprintf("/%s/configuration", database))
-	r, err := d.client.Get(url, nil)
+	r, err := d.client.Get(ctx, url, nil)
 	if err != nil {
 		return DatabaseConfig{}, fmt.Errorf("failed to get database: %w", err)
 	}
@@ -405,13 +406,13 @@ func (d *DatabasesClient) GetConfig(database string) (DatabaseConfig, error) {
 	return unmarshal[DatabaseConfig](r)
 }
 
-func (d *DatabasesClient) UpdateConfig(database string, config DatabaseConfig) error {
+func (d *DatabasesClient) UpdateConfig(ctx context.Context, database string, config DatabaseConfig) error {
 	url := d.URL(fmt.Sprintf("/%s/configuration", database))
 	body, err := marshal(config)
 	if err != nil {
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
-	r, err := d.client.Patch(url, body)
+	r, err := d.client.Patch(ctx, url, body)
 	if err != nil {
 		return fmt.Errorf("failed to update database: %w", err)
 	}

--- a/feedback.go
+++ b/feedback.go
@@ -1,0 +1,28 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type FeedbackClient client
+
+func (d *FeedbackClient) Submit(summary, feedback string) error {
+	body := struct{ Summary, Feedback string }{summary, feedback}
+	reader, err := marshal(body)
+	if err != nil {
+		return fmt.Errorf("could not marshal feedback: %w", err)
+	}
+
+	r, err := d.client.Post("/v1/feedback", reader)
+	if err != nil {
+		return fmt.Errorf("failed to post feedback: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to post feedback: %w", parseResponseError(r))
+	}
+
+	return nil
+}

--- a/feedback.go
+++ b/feedback.go
@@ -8,14 +8,14 @@ import (
 
 type FeedbackClient client
 
-func (d *FeedbackClient) Submit(ctx context.Context, summary, feedback string) error {
+func (f *FeedbackClient) Submit(ctx context.Context, summary, feedback string) error {
 	body := struct{ Summary, Feedback string }{summary, feedback}
 	reader, err := marshal(body)
 	if err != nil {
 		return fmt.Errorf("could not marshal feedback: %w", err)
 	}
 
-	r, err := d.client.Post(ctx, "/v1/feedback", reader)
+	r, err := f.client.Post(ctx, "/v1/feedback", reader)
 	if err != nil {
 		return fmt.Errorf("failed to post feedback: %s", err)
 	}

--- a/feedback.go
+++ b/feedback.go
@@ -1,20 +1,21 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 type FeedbackClient client
 
-func (d *FeedbackClient) Submit(summary, feedback string) error {
+func (d *FeedbackClient) Submit(ctx context.Context, summary, feedback string) error {
 	body := struct{ Summary, Feedback string }{summary, feedback}
 	reader, err := marshal(body)
 	if err != nil {
 		return fmt.Errorf("could not marshal feedback: %w", err)
 	}
 
-	r, err := d.client.Post("/v1/feedback", reader)
+	r, err := d.client.Post(ctx, "/v1/feedback", reader)
 	if err != nil {
 		return fmt.Errorf("failed to post feedback: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alehechka/turso-go
+
+go 1.22.0

--- a/groups.go
+++ b/groups.go
@@ -16,96 +16,92 @@ type Group struct {
 	Version   string   `json:"version"`
 }
 
-func (d *GroupsClient) List(ctx context.Context) ([]Group, error) {
-	r, err := d.client.Get(ctx, d.URL(""), nil)
+func (g *GroupsClient) List(ctx context.Context) ([]Group, error) {
+	res, err := g.client.Get(ctx, g.URL(""), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get groups: %s", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return nil, notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return nil, g.client.notMemberErr()
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get database groups: received status code%w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get database groups: received status code%w", parseResponseError(res))
 	}
 
 	type ListResponse struct {
 		Groups []Group `json:"groups"`
 	}
-	resp, err := unmarshal[ListResponse](r)
+	resp, err := unmarshal[ListResponse](res)
 	return resp.Groups, err
 }
 
-func (d *GroupsClient) Get(ctx context.Context, name string) (Group, error) {
-	r, err := d.client.Get(ctx, d.URL("/"+name), nil)
+func (g *GroupsClient) Get(ctx context.Context, name string) (Group, error) {
+	res, err := g.client.Get(ctx, g.URL("/"+name), nil)
 	if err != nil {
 		return Group{}, fmt.Errorf("failed to get group %s: %w", name, err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return Group{}, notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return Group{}, g.client.notMemberErr()
 	}
 
-	if r.StatusCode == http.StatusNotFound {
+	if res.StatusCode == http.StatusNotFound {
 		return Group{}, fmt.Errorf("group %s was not found", name)
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return Group{}, fmt.Errorf("failed to get database group: received status code%w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return Group{}, fmt.Errorf("failed to get database group: received status code%w", parseResponseError(res))
 	}
 
 	type Response struct {
 		Group Group `json:"group"`
 	}
-	resp, err := unmarshal[Response](r)
+	resp, err := unmarshal[Response](res)
 	return resp.Group, err
 }
 
-func (d *GroupsClient) Delete(ctx context.Context, group string) error {
-	url := d.URL("/" + group)
-	r, err := d.client.Delete(ctx, url, nil)
+func (g *GroupsClient) Delete(ctx context.Context, group string) error {
+	url := g.URL("/" + group)
+	res, err := g.client.Delete(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete group: %s", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
-	if r.StatusCode == http.StatusNotFound {
+	if res.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("group %s not found", group)
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to delete group: received status code%w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete group: received status code%w", parseResponseError(res))
 	}
 
 	return nil
 }
 
-func (d *GroupsClient) Create(ctx context.Context, name, location, version string) error {
+func (g *GroupsClient) Create(ctx context.Context, name, location, version string) error {
 	type Body struct{ Name, Location, Version string }
 	body, err := marshal(Body{name, location, version})
 	if err != nil {
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	res, err := d.client.Post(ctx, d.URL(""), body)
+	res, err := g.client.Post(ctx, g.URL(""), body)
 	if err != nil {
 		return fmt.Errorf("failed to create group: %s", err)
 	}
 	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(res.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
 	if res.StatusCode == http.StatusUnprocessableEntity {
@@ -118,16 +114,15 @@ func (d *GroupsClient) Create(ctx context.Context, name, location, version strin
 	return nil
 }
 
-func (d *GroupsClient) Unarchive(ctx context.Context, name string) error {
-	res, err := d.client.Post(ctx, d.URL("/"+name+"/unarchive"), nil)
+func (g *GroupsClient) Unarchive(ctx context.Context, name string) error {
+	res, err := g.client.Post(ctx, g.URL("/"+name+"/unarchive"), nil)
 	if err != nil {
 		return fmt.Errorf("failed to unarchive group: %s", err)
 	}
 	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(res.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -136,16 +131,15 @@ func (d *GroupsClient) Unarchive(ctx context.Context, name string) error {
 	return nil
 }
 
-func (d *GroupsClient) AddLocation(ctx context.Context, name, location string) error {
-	res, err := d.client.Post(ctx, d.URL("/"+name+"/locations/"+location), nil)
+func (g *GroupsClient) AddLocation(ctx context.Context, name, location string) error {
+	res, err := g.client.Post(ctx, g.URL("/"+name+"/locations/"+location), nil)
 	if err != nil {
 		return fmt.Errorf("failed to post group location request: %s", err)
 	}
 	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(res.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -154,16 +148,15 @@ func (d *GroupsClient) AddLocation(ctx context.Context, name, location string) e
 	return nil
 }
 
-func (d *GroupsClient) RemoveLocation(ctx context.Context, name, location string) error {
-	res, err := d.client.Delete(ctx, d.URL("/"+name+"/locations/"+location), nil)
+func (g *GroupsClient) RemoveLocation(ctx context.Context, name, location string) error {
+	res, err := g.client.Delete(ctx, g.URL("/"+name+"/locations/"+location), nil)
 	if err != nil {
 		return fmt.Errorf("failed to post group location request: %s", err)
 	}
 	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(res.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -172,16 +165,15 @@ func (d *GroupsClient) RemoveLocation(ctx context.Context, name, location string
 	return nil
 }
 
-func (d *GroupsClient) WaitLocation(ctx context.Context, name, location string) error {
-	res, err := d.client.Get(ctx, d.URL("/"+name+"/locations/"+location+"/wait"), nil)
+func (g *GroupsClient) WaitLocation(ctx context.Context, name, location string) error {
+	res, err := g.client.Get(ctx, g.URL("/"+name+"/locations/"+location+"/wait"), nil)
 	if err != nil {
 		return fmt.Errorf("failed to send wait location request: %s", err)
 	}
 	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(res.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -202,12 +194,12 @@ type GroupTokenRequest struct {
 	Permissions *PermissionsClaim `json:"permissions,omitempty"`
 }
 
-func (d *GroupsClient) Token(ctx context.Context, group string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
+func (g *GroupsClient) Token(ctx context.Context, group string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
 	authorization := ""
 	if readOnly {
 		authorization = "&authorization=read-only"
 	}
-	url := d.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", group, expiration, authorization))
+	url := g.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", group, expiration, authorization))
 
 	req := GroupTokenRequest{permissions}
 	body, err := marshal(req)
@@ -215,76 +207,73 @@ func (d *GroupsClient) Token(ctx context.Context, group string, expiration strin
 		return "", fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	r, err := d.client.Post(ctx, url, body)
+	res, err := g.client.Post(ctx, url, body)
 	if err != nil {
 		return "", fmt.Errorf("failed to get database token: %w", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return "", notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return "", g.client.notMemberErr()
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to get database token: %w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get database token: %w", parseResponseError(res))
 	}
 
 	type JwtResponse struct{ Jwt string }
-	data, err := unmarshal[JwtResponse](r)
+	data, err := unmarshal[JwtResponse](res)
 	if err != nil {
 		return "", err
 	}
 	return data.Jwt, nil
 }
 
-func (d *GroupsClient) Rotate(ctx context.Context, group string) error {
-	url := d.URL(fmt.Sprintf("/%s/auth/rotate", group))
-	r, err := d.client.Post(ctx, url, nil)
+func (g *GroupsClient) Rotate(ctx context.Context, group string) error {
+	url := g.URL(fmt.Sprintf("/%s/auth/rotate", group))
+	res, err := g.client.Post(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to rotate database keys: %w", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to rotate database keys: %w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to rotate database keys: %w", parseResponseError(res))
 	}
 
 	return nil
 }
 
-func (d *GroupsClient) Update(ctx context.Context, group string, version, extensions string) error {
+func (g *GroupsClient) Update(ctx context.Context, group string, version, extensions string) error {
 	type Body struct{ Version, Extensions string }
 	body, err := marshal(Body{version, extensions})
 	if err != nil {
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	url := d.URL(fmt.Sprintf("/%s/update", group))
-	r, err := d.client.Post(ctx, url, body)
+	url := g.URL(fmt.Sprintf("/%s/update", group))
+	res, err := g.client.Post(ctx, url, body)
 	if err != nil {
 		return fmt.Errorf("failed to rotate database keys: %w", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
-	if r.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to update group: %w", parseResponseError(r))
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update group: %w", parseResponseError(res))
 	}
 
 	return nil
 }
 
-func (d *GroupsClient) Transfer(ctx context.Context, group string, to string) error {
+func (g *GroupsClient) Transfer(ctx context.Context, group string, to string) error {
 	type Body struct {
 		Organization string `json:"organization"`
 	}
@@ -293,30 +282,29 @@ func (d *GroupsClient) Transfer(ctx context.Context, group string, to string) er
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	url := d.URL(fmt.Sprintf("/%s/transfer", group))
-	r, err := d.client.Post(ctx, url, body)
+	url := g.URL(fmt.Sprintf("/%s/transfer", group))
+	res, err := g.client.Post(ctx, url, body)
 	if err != nil {
 		return fmt.Errorf("failed to transfer group: %w", err)
 	}
-	defer r.Body.Close()
+	defer res.Body.Close()
 
-	org := d.client.Org
-	if isNotMemberErr(r.StatusCode, org) {
-		return notMemberErr(org)
+	if g.client.isNotMemberErr(res.StatusCode) {
+		return g.client.notMemberErr()
 	}
 
-	if r.StatusCode != http.StatusOK {
-		err := parseResponseError(r)
+	if res.StatusCode != http.StatusOK {
+		err := parseResponseError(res)
 		return fmt.Errorf("failed to transfer group: %w", err)
 	}
 
 	return nil
 }
 
-func (d *GroupsClient) URL(suffix string) string {
+func (g *GroupsClient) URL(suffix string) string {
 	prefix := "/v1"
-	if d.client.Org != "" {
-		prefix = "/v1/organizations/" + d.client.Org
+	if g.client.Org != "" {
+		prefix = "/v1/organizations/" + g.client.Org
 	}
 	return prefix + "/groups" + suffix
 }

--- a/groups.go
+++ b/groups.go
@@ -1,0 +1,321 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type GroupsClient client
+
+type Group struct {
+	Name      string   `json:"name"`
+	Locations []string `json:"locations"`
+	Primary   string   `json:"primary"`
+	Archived  bool     `json:"archived"`
+	Version   string   `json:"version"`
+}
+
+func (d *GroupsClient) List() ([]Group, error) {
+	r, err := d.client.Get(d.URL(""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get groups: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get database groups: received status code%w", parseResponseError(r))
+	}
+
+	type ListResponse struct {
+		Groups []Group `json:"groups"`
+	}
+	resp, err := unmarshal[ListResponse](r)
+	return resp.Groups, err
+}
+
+func (d *GroupsClient) Get(name string) (Group, error) {
+	r, err := d.client.Get(d.URL("/"+name), nil)
+	if err != nil {
+		return Group{}, fmt.Errorf("failed to get group %s: %w", name, err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return Group{}, notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return Group{}, fmt.Errorf("group %s was not found", name)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return Group{}, fmt.Errorf("failed to get database group: received status code%w", parseResponseError(r))
+	}
+
+	type Response struct {
+		Group Group `json:"group"`
+	}
+	resp, err := unmarshal[Response](r)
+	return resp.Group, err
+}
+
+func (d *GroupsClient) Delete(group string) error {
+	url := d.URL("/" + group)
+	r, err := d.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete group: %s", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("group %s not found", group)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete group: received status code%w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (d *GroupsClient) Create(name, location, version string) error {
+	type Body struct{ Name, Location, Version string }
+	body, err := marshal(Body{name, location, version})
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	res, err := d.client.Post(d.URL(""), body)
+	if err != nil {
+		return fmt.Errorf("failed to create group: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("group name '%s' is not available", name)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *GroupsClient) Unarchive(name string) error {
+	res, err := d.client.Post(d.URL("/"+name+"/unarchive"), nil)
+	if err != nil {
+		return fmt.Errorf("failed to unarchive group: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *GroupsClient) AddLocation(name, location string) error {
+	res, err := d.client.Post(d.URL("/"+name+"/locations/"+location), nil)
+	if err != nil {
+		return fmt.Errorf("failed to post group location request: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *GroupsClient) RemoveLocation(name, location string) error {
+	res, err := d.client.Delete(d.URL("/"+name+"/locations/"+location), nil)
+	if err != nil {
+		return fmt.Errorf("failed to post group location request: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+func (d *GroupsClient) WaitLocation(name, location string) error {
+	res, err := d.client.Get(d.URL("/"+name+"/locations/"+location+"/wait"), nil)
+	if err != nil {
+		return fmt.Errorf("failed to send wait location request: %s", err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return parseResponseError(res)
+	}
+	return nil
+}
+
+type Entities struct {
+	DBNames []string `json:"databases,omitempty"`
+}
+
+type PermissionsClaim struct {
+	ReadAttach Entities `json:"read_attach,omitempty"`
+}
+
+type GroupTokenRequest struct {
+	Permissions *PermissionsClaim `json:"permissions,omitempty"`
+}
+
+func (d *GroupsClient) Token(group string, expiration string, readOnly bool, permissions *PermissionsClaim) (string, error) {
+	authorization := ""
+	if readOnly {
+		authorization = "&authorization=read-only"
+	}
+	url := d.URL(fmt.Sprintf("/%s/auth/tokens?expiration=%s%s", group, expiration, authorization))
+
+	req := GroupTokenRequest{permissions}
+	body, err := marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := d.client.Post(url, body)
+	if err != nil {
+		return "", fmt.Errorf("failed to get database token: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return "", notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get database token: %w", parseResponseError(r))
+	}
+
+	type JwtResponse struct{ Jwt string }
+	data, err := unmarshal[JwtResponse](r)
+	if err != nil {
+		return "", err
+	}
+	return data.Jwt, nil
+}
+
+func (d *GroupsClient) Rotate(group string) error {
+	url := d.URL(fmt.Sprintf("/%s/auth/rotate", group))
+	r, err := d.client.Post(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to rotate database keys: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to rotate database keys: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (d *GroupsClient) Update(group string, version, extensions string) error {
+	type Body struct{ Version, Extensions string }
+	body, err := marshal(Body{version, extensions})
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	url := d.URL(fmt.Sprintf("/%s/update", group))
+	r, err := d.client.Post(url, body)
+	if err != nil {
+		return fmt.Errorf("failed to rotate database keys: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update group: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (d *GroupsClient) Transfer(group string, to string) error {
+	type Body struct {
+		Organization string `json:"organization"`
+	}
+	body, err := marshal(Body{to})
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	url := d.URL(fmt.Sprintf("/%s/transfer", group))
+	r, err := d.client.Post(url, body)
+	if err != nil {
+		return fmt.Errorf("failed to transfer group: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		err := parseResponseError(r)
+		return fmt.Errorf("failed to transfer group: %w", err)
+	}
+
+	return nil
+}
+
+func (d *GroupsClient) URL(suffix string) string {
+	prefix := "/v1"
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
+	}
+	return prefix + "/groups" + suffix
+}

--- a/instances.go
+++ b/instances.go
@@ -1,0 +1,155 @@
+package turso
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type Instance struct {
+	Uuid     string
+	Name     string
+	Type     string
+	Region   string
+	Hostname string
+}
+
+type InstancesClient client
+
+type CreateInstanceLocationError struct {
+	err string
+}
+
+func (e *CreateInstanceLocationError) Error() string {
+	return e.err
+}
+
+func (i *InstancesClient) List(db string) ([]Instance, error) {
+	r, err := i.client.Get(i.URL(db, ""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list instances of %s: %s", db, err)
+	}
+	defer r.Body.Close()
+
+	org := i.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response with status code %d", r.StatusCode)
+	}
+
+	type ListResponse struct{ Instances []Instance }
+	resp, err := unmarshal[ListResponse](r)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Instances, nil
+}
+
+func (i *InstancesClient) Delete(db, instance string) error {
+	url := i.URL(db, "/"+instance)
+	r, err := i.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to destroy instances %s of %s: %s", instance, db, err)
+	}
+	defer r.Body.Close()
+
+	org := i.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusBadRequest {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("response with status code %d", r.StatusCode)
+	}
+
+	return nil
+}
+
+func (d *InstancesClient) Create(dbName, location string) (*Instance, error) {
+	type Body struct {
+		Location string
+	}
+	body, err := marshal(Body{location})
+	if err != nil {
+		return nil, fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	url := d.URL(dbName, "")
+	res, err := d.client.Post(url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new instances for %s: %s", dbName, err)
+	}
+	defer res.Body.Close()
+
+	org := d.client.Org
+	if isNotMemberErr(res.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if res.StatusCode >= http.StatusInternalServerError {
+		return nil, &CreateInstanceLocationError{fmt.Sprintf("failed to create new instance: %s", res.Status)}
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, parseResponseError(res)
+	}
+
+	data, err := unmarshal[struct{ Instance Instance }](res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	return &data.Instance, nil
+}
+
+func (i *InstancesClient) Wait(db, instance string) error {
+	url := i.URL(db, "/"+instance+"/wait")
+	r, err := i.client.Get(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to wait for instance %s to of %s be ready: %s", instance, db, err)
+	}
+	defer r.Body.Close()
+
+	org := i.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusBadRequest {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("response with status code %d", r.StatusCode)
+	}
+
+	return nil
+}
+
+func (d *InstancesClient) URL(database, suffix string) string {
+	prefix := "/v1"
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
+	}
+	return fmt.Sprintf("%s/databases/%s/instances%s", prefix, database, suffix)
+}

--- a/instances.go
+++ b/instances.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -24,8 +25,8 @@ func (e *CreateInstanceLocationError) Error() string {
 	return e.err
 }
 
-func (i *InstancesClient) List(db string) ([]Instance, error) {
-	r, err := i.client.Get(i.URL(db, ""), nil)
+func (i *InstancesClient) List(ctx context.Context, db string) ([]Instance, error) {
+	r, err := i.client.Get(ctx, i.URL(db, ""), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list instances of %s: %s", db, err)
 	}
@@ -49,9 +50,9 @@ func (i *InstancesClient) List(db string) ([]Instance, error) {
 	return resp.Instances, nil
 }
 
-func (i *InstancesClient) Delete(db, instance string) error {
+func (i *InstancesClient) Delete(ctx context.Context, db, instance string) error {
 	url := i.URL(db, "/"+instance)
-	r, err := i.client.Delete(url, nil)
+	r, err := i.client.Delete(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to destroy instances %s of %s: %s", instance, db, err)
 	}
@@ -79,7 +80,7 @@ func (i *InstancesClient) Delete(db, instance string) error {
 	return nil
 }
 
-func (d *InstancesClient) Create(dbName, location string) (*Instance, error) {
+func (d *InstancesClient) Create(ctx context.Context, dbName, location string) (*Instance, error) {
 	type Body struct {
 		Location string
 	}
@@ -89,7 +90,7 @@ func (d *InstancesClient) Create(dbName, location string) (*Instance, error) {
 	}
 
 	url := d.URL(dbName, "")
-	res, err := d.client.Post(url, body)
+	res, err := d.client.Post(ctx, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new instances for %s: %s", dbName, err)
 	}
@@ -116,9 +117,9 @@ func (d *InstancesClient) Create(dbName, location string) (*Instance, error) {
 	return &data.Instance, nil
 }
 
-func (i *InstancesClient) Wait(db, instance string) error {
+func (i *InstancesClient) Wait(ctx context.Context, db, instance string) error {
 	url := i.URL(db, "/"+instance+"/wait")
-	r, err := i.client.Get(url, nil)
+	r, err := i.client.Get(ctx, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to wait for instance %s to of %s be ready: %s", instance, db, err)
 	}

--- a/invoices.go
+++ b/invoices.go
@@ -1,0 +1,48 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type InvoicesClient client
+
+type Invoice struct {
+	Number          string `json:"invoice_number"`
+	Amount          string `json:"amount_due"`
+	DueDate         string `json:"due_date"`
+	PaidAt          string `json:"paid_at"`
+	PaymentFailedAt string `json:"payment_failed_at"`
+	InvoicePdf      string `json:"invoice_pdf"`
+}
+
+func (i *InvoicesClient) List() ([]Invoice, error) {
+	r, err := i.client.Get(i.URL(""), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invoices: %w", err)
+	}
+	defer r.Body.Close()
+
+	org := i.client.Org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get invoices: received status code%w", parseResponseError(r))
+	}
+
+	type ListResponse struct {
+		Invoices []Invoice `json:"invoices"`
+	}
+	resp, err := unmarshal[ListResponse](r)
+	return resp.Invoices, err
+}
+
+func (i *InvoicesClient) URL(suffix string) string {
+	prefix := "/v1"
+	if i.client.Org != "" {
+		prefix = "/v1/organizations/" + i.client.Org
+	}
+	return prefix + "/invoices" + suffix
+}

--- a/invoices.go
+++ b/invoices.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -16,8 +17,8 @@ type Invoice struct {
 	InvoicePdf      string `json:"invoice_pdf"`
 }
 
-func (i *InvoicesClient) List() ([]Invoice, error) {
-	r, err := i.client.Get(i.URL(""), nil)
+func (i *InvoicesClient) List(ctx context.Context) ([]Invoice, error) {
+	r, err := i.client.Get(ctx, i.URL(""), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get invoices: %w", err)
 	}

--- a/locations.go
+++ b/locations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 type LocationsClient client
@@ -88,33 +87,4 @@ func (c *LocationsClient) Closest(ctx context.Context) (string, error) {
 	}
 
 	return data.Server, nil
-}
-
-func ProbeLocation(location string) *time.Duration {
-	client := &http.Client{Timeout: 2 * time.Second}
-	req, err := http.NewRequest("GET", "http://region.turso.io:8080/", nil)
-	if err != nil {
-		return nil
-	}
-	req.Header.Add("fly-prefer-region", location)
-
-	start := time.Now()
-	r, err := client.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer r.Body.Close()
-
-	dur := time.Since(start)
-	if r.StatusCode != http.StatusOK {
-		return nil
-	}
-	data, err := unmarshal[ClosestLocationResponse](r)
-	if err != nil {
-		return nil
-	}
-	if data.Server != location {
-		return nil
-	}
-	return &dur
 }

--- a/locations.go
+++ b/locations.go
@@ -1,0 +1,119 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type LocationsClient client
+
+type LocationsResponse struct {
+	Locations map[string]string
+}
+
+type Location struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}
+
+type LocationResponse struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	Closest     []Location
+}
+
+func (c *LocationsClient) List() (map[string]string, error) {
+	r, err := c.client.Get("/v1/locations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request locations: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get locations: %w", parseResponseError(r))
+
+	}
+
+	data, err := unmarshal[LocationsResponse](r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize locations response: %w", err)
+	}
+
+	return data.Locations, nil
+}
+
+func (c *LocationsClient) Get(location string) (LocationResponse, error) {
+	r, err := c.client.Get("/v1/locations/"+location, nil)
+	if err != nil {
+		return LocationResponse{}, fmt.Errorf("failed to request location %s: %w", location, err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return LocationResponse{}, fmt.Errorf("failed to get location %s: %s", location, r.Status)
+	}
+
+	data, err := unmarshal[struct {
+		Location LocationResponse `json:"location"`
+	}](r)
+
+	if err != nil {
+		return LocationResponse{}, fmt.Errorf("failed to deserialize location response: %w", err)
+	}
+
+	return data.Location, nil
+}
+
+type ClosestLocationResponse struct {
+	Server string
+}
+
+func (c *LocationsClient) Closest() (string, error) {
+	r, err := c.client.Get("https://region.turso.io", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to request closest: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get closest location: %w", parseResponseError(r))
+
+	}
+
+	data, err := unmarshal[ClosestLocationResponse](r)
+	if err != nil {
+		return "", fmt.Errorf("failed to deserialize locations response: %w", err)
+	}
+
+	return data.Server, nil
+}
+
+func ProbeLocation(location string) *time.Duration {
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequest("GET", "http://region.turso.io:8080/", nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Add("fly-prefer-region", location)
+
+	start := time.Now()
+	r, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer r.Body.Close()
+
+	dur := time.Since(start)
+	if r.StatusCode != http.StatusOK {
+		return nil
+	}
+	data, err := unmarshal[ClosestLocationResponse](r)
+	if err != nil {
+		return nil
+	}
+	if data.Server != location {
+		return nil
+	}
+	return &dur
+}

--- a/locations.go
+++ b/locations.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,8 +24,8 @@ type LocationResponse struct {
 	Closest     []Location
 }
 
-func (c *LocationsClient) List() (map[string]string, error) {
-	r, err := c.client.Get("/v1/locations", nil)
+func (c *LocationsClient) List(ctx context.Context) (map[string]string, error) {
+	r, err := c.client.Get(ctx, "/v1/locations", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request locations: %s", err)
 	}
@@ -43,8 +44,8 @@ func (c *LocationsClient) List() (map[string]string, error) {
 	return data.Locations, nil
 }
 
-func (c *LocationsClient) Get(location string) (LocationResponse, error) {
-	r, err := c.client.Get("/v1/locations/"+location, nil)
+func (c *LocationsClient) Get(ctx context.Context, location string) (LocationResponse, error) {
+	r, err := c.client.Get(ctx, "/v1/locations/"+location, nil)
 	if err != nil {
 		return LocationResponse{}, fmt.Errorf("failed to request location %s: %w", location, err)
 	}
@@ -69,8 +70,8 @@ type ClosestLocationResponse struct {
 	Server string
 }
 
-func (c *LocationsClient) Closest() (string, error) {
-	r, err := c.client.Get("https://region.turso.io", nil)
+func (c *LocationsClient) Closest(ctx context.Context) (string, error) {
+	r, err := c.client.Get(ctx, "https://region.turso.io", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to request closest: %s", err)
 	}

--- a/organizations.go
+++ b/organizations.go
@@ -326,14 +326,3 @@ func (c *OrganizationsClient) RemoveMember(ctx context.Context, username string)
 func (c *OrganizationsClient) MembersURL(suffix string) (string, error) {
 	return "/v1/organizations/" + c.client.Org + "/members" + suffix, nil
 }
-
-func isNotMemberErr(status int, org string) bool {
-	if status == http.StatusForbidden && org != "" {
-		return true
-	}
-	return false
-}
-
-func notMemberErr(org string) error {
-	return fmt.Errorf("not a member of organization %s", org)
-}

--- a/organizations.go
+++ b/organizations.go
@@ -1,0 +1,338 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type OrganizationsClient client
+
+type Organization struct {
+	Name     string `json:"name,omitempty"`
+	Slug     string `json:"slug,omitempty"`
+	Type     string `json:"type,omitempty"`
+	StripeID string `json:"stripe_id,omitempty"`
+	Overages bool   `json:"overages,omitempty"`
+}
+
+func (c *OrganizationsClient) List() ([]Organization, error) {
+	r, err := c.client.Get("/v2/organizations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request organizations: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list organizations: %w", parseResponseError(r))
+	}
+
+	type ListResponse struct {
+		Orgs []Organization `json:"organizations"`
+	}
+
+	data, err := unmarshal[ListResponse](r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize list organizations response: %w", err)
+	}
+
+	return data.Orgs, nil
+}
+
+func (c *OrganizationsClient) Create(name string, stripeId string, dryRun bool) (Organization, error) {
+	body, err := marshal(Organization{Name: name, StripeID: stripeId})
+	if err != nil {
+		return Organization{}, fmt.Errorf("failed to marshall create org request body: %s", err)
+	}
+
+	r, err := c.client.Post(fmt.Sprintf("/v1/organizations?dry_run=%v", dryRun), body)
+	if err != nil {
+		return Organization{}, fmt.Errorf("failed to post organization: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusConflict {
+		return Organization{}, fmt.Errorf("failed to create organization %s: name already exists", name)
+	}
+
+	if r.StatusCode == http.StatusPaymentRequired {
+		return Organization{}, fmt.Errorf("failed to create organization %s: you need to upgrade your plan", name)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return Organization{}, fmt.Errorf("failed to create organization: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct{ Org Organization }](r)
+	if err != nil {
+		return Organization{}, fmt.Errorf("failed to deserialize create organizations response: %w", err)
+	}
+
+	return data.Org, nil
+}
+
+func (c *OrganizationsClient) Delete(slug string) error {
+	r, err := c.client.Delete("/v1/organizations/"+slug, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("could not find organization %s", slug)
+	}
+
+	switch r.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusBadRequest:
+		return parseResponseError(r)
+	case http.StatusForbidden:
+		return fmt.Errorf("you do not have permission to delete organization %s", slug)
+	default:
+		return fmt.Errorf("failed to delete organization: %w", parseResponseError(r))
+	}
+}
+
+type OrgTotal struct {
+	RowsRead         uint64 `json:"rows_read,omitempty"`
+	RowsWritten      uint64 `json:"rows_written,omitempty"`
+	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+	BytesSynced      uint64 `json:"bytes_synced,omitempty"`
+	Databases        uint64 `json:"databases,omitempty"`
+	Locations        uint64 `json:"locations,omitempty"`
+	Groups           uint64 `json:"groups,omitempty"`
+}
+
+type OrgUsage struct {
+	UUID      string    `json:"uuid,omitempty"`
+	Usage     OrgTotal  `json:"usage"`
+	Databases []DbUsage `json:"databases"`
+}
+
+type OrgUsageResponse struct {
+	OrgUsage OrgUsage `json:"organization"`
+}
+
+func (c *OrganizationsClient) Usage() (OrgUsage, error) {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+
+	r, err := c.client.Get(prefix+"/usage", nil)
+	if err != nil {
+		return OrgUsage{}, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		err, _ := unmarshal[string](r)
+		return OrgUsage{}, fmt.Errorf("failed to get database usage: %d %s", r.StatusCode, err)
+	}
+
+	body, err := unmarshal[OrgUsageResponse](r)
+	if err != nil {
+		return OrgUsage{}, err
+	}
+	return body.OrgUsage, nil
+}
+
+func (c *OrganizationsClient) SetOverages(slug string, toggle bool) error {
+	path := "/v1/organizations/" + slug
+	body, err := marshal(map[string]bool{"overages": toggle})
+	if err != nil {
+		return fmt.Errorf("failed to marshall set overages request body: %s", err)
+	}
+	r, err := c.client.Patch(path, body)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to set overages: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+type Member struct {
+	Name string `json:"username,omitempty"`
+	Role string `json:"role,omitempty"`
+}
+
+type Invite struct {
+	Email    string `json:"email,omitempty"`
+	Role     string `json:"role,omitempty"`
+	Accepted bool   `json:"accepted,omitempty"`
+}
+
+func (c *OrganizationsClient) ListMembers() ([]Member, error) {
+	url, err := c.MembersURL("")
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := c.client.Get(url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request organization members: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("only organization admins or owners can list members")
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list organization members: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct{ Members []Member }](r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize list organizations response: %w", err)
+	}
+
+	return data.Members, nil
+}
+
+func (c *OrganizationsClient) AddMember(username, role string) error {
+	url, err := c.MembersURL("")
+	if err != nil {
+		return err
+	}
+
+	body, err := marshal(Member{Name: username, Role: role})
+	if err != nil {
+		return fmt.Errorf("failed to marshall add member request body: %s", err)
+	}
+
+	r, err := c.client.Post(url, body)
+	if err != nil {
+		return fmt.Errorf("failed to post organization member: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization admins or owners can add members")
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to add organization member: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (c *OrganizationsClient) InviteMember(email, role string) error {
+	prefix := "/v1/organizations/" + c.client.Org
+
+	body, err := marshal(Invite{Email: email, Role: role})
+	if err != nil {
+		return fmt.Errorf("failed to marshall invite email request body: %s", err)
+	}
+
+	r, err := c.client.Post(prefix+"/invite", body)
+	if err != nil {
+		return fmt.Errorf("failed to invite organization member: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization admins or owners can invite members")
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to invite organization member: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (c *OrganizationsClient) DeleteInvite(email string) error {
+	prefix := "/v1/organizations/" + c.client.Org
+
+	r, err := c.client.Delete(prefix+"/invites/"+email, nil)
+	if err != nil {
+		return fmt.Errorf("failed to remove pending invite: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization admins or owners can invite members")
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("invite for %s not found", email)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete pending invite: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (c *OrganizationsClient) ListInvites() ([]Invite, error) {
+	prefix := "/v1/organizations/" + c.client.Org
+
+	r, err := c.client.Get(prefix+"/invites", nil)
+	if err != nil {
+		return []Invite{}, fmt.Errorf("failed to list invites: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return []Invite{}, fmt.Errorf("only organization admins or owners can list invites")
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return []Invite{}, fmt.Errorf("failed to list invites: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct {
+		Invites []Invite `json:"invites"`
+	}](r)
+	if err != nil {
+		return []Invite{}, fmt.Errorf("failed to deserialize list invites response: %w", err)
+	}
+
+	return data.Invites, nil
+}
+
+func (c *OrganizationsClient) RemoveMember(username string) error {
+	url, err := c.MembersURL("/" + username)
+	if err != nil {
+		return err
+	}
+
+	r, err := c.client.Delete(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization member: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization admins or owners can remove members")
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to remove organization member: %w", parseResponseError(r))
+	}
+
+	return nil
+}
+
+func (c *OrganizationsClient) MembersURL(suffix string) (string, error) {
+	return "/v1/organizations/" + c.client.Org + "/members" + suffix, nil
+}
+
+func isNotMemberErr(status int, org string) bool {
+	if status == http.StatusForbidden && org != "" {
+		return true
+	}
+	return false
+}
+
+func notMemberErr(org string) error {
+	return fmt.Errorf("not a member of organization %s", org)
+}

--- a/plans.go
+++ b/plans.go
@@ -1,0 +1,100 @@
+package turso
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type PlansClient client
+
+type Plan struct {
+	Name   string `json:"name"`
+	Price  string `json:"price"`
+	Quotas struct {
+		RowsRead    uint64 `json:"rowsRead"`
+		RowsWritten uint64 `json:"rowsWritten"`
+		Databases   uint64 `json:"databases"`
+		BytesSynced uint64 `json:"bytesSynced"`
+		Locations   uint64 `json:"locations"`
+		Storage     uint64 `json:"storage"`
+		Groups      uint64 `json:"groups"`
+	}
+}
+
+func (c *PlansClient) List() ([]Plan, error) {
+	r, err := c.client.Get("/v1/plans", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plan list: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to list plans with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Plans []Plan }](r)
+	return resp.Plans, err
+}
+
+type SubscriptionClient client
+
+type Subscription struct {
+	Plan     string `json:"plan"`
+	Timeline string `json:"timeline"`
+	Overages bool   `json:"overages"`
+}
+
+func (c *SubscriptionClient) Get() (Subscription, error) {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+
+	r, err := c.client.Get(prefix+"/subscription", nil)
+	if err != nil {
+		return Subscription{}, fmt.Errorf("failed to get organization plan: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != 200 {
+		return Subscription{}, fmt.Errorf("failed to get organization plan with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	resp, err := unmarshal[struct{ Subscription Subscription }](r)
+	return resp.Subscription, err
+}
+
+var ErrPaymentRequired = errors.New("payment required")
+
+func (c *SubscriptionClient) Update(plan, timeline string, overages *bool) error {
+	prefix := "/v1"
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
+	}
+
+	body, err := marshal(struct {
+		Plan     string `json:"plan"`
+		Timeline string `json:"timeline,omitempty"`
+		Overages *bool  `json:"overages,omitempty"`
+	}{plan, timeline, overages})
+	if err != nil {
+		return fmt.Errorf("could not serialize request body: %w", err)
+	}
+
+	r, err := c.client.Post(prefix+"/subscription", body)
+	if err != nil {
+		return fmt.Errorf("failed to set organization plan: %w", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusPaymentRequired {
+		return ErrPaymentRequired
+	}
+
+	if r.StatusCode != 200 {
+		return fmt.Errorf("failed to set organization plan with status %s: %v", r.Status, parseResponseError(r))
+	}
+
+	return nil
+}

--- a/plans.go
+++ b/plans.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,8 +23,8 @@ type Plan struct {
 	}
 }
 
-func (c *PlansClient) List() ([]Plan, error) {
-	r, err := c.client.Get("/v1/plans", nil)
+func (c *PlansClient) List(ctx context.Context) ([]Plan, error) {
+	r, err := c.client.Get(ctx, "/v1/plans", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get plan list: %w", err)
 	}
@@ -45,13 +46,13 @@ type Subscription struct {
 	Overages bool   `json:"overages"`
 }
 
-func (c *SubscriptionClient) Get() (Subscription, error) {
+func (c *SubscriptionClient) Get(ctx context.Context) (Subscription, error) {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
 	}
 
-	r, err := c.client.Get(prefix+"/subscription", nil)
+	r, err := c.client.Get(ctx, prefix+"/subscription", nil)
 	if err != nil {
 		return Subscription{}, fmt.Errorf("failed to get organization plan: %w", err)
 	}
@@ -67,7 +68,7 @@ func (c *SubscriptionClient) Get() (Subscription, error) {
 
 var ErrPaymentRequired = errors.New("payment required")
 
-func (c *SubscriptionClient) Update(plan, timeline string, overages *bool) error {
+func (c *SubscriptionClient) Update(ctx context.Context, plan, timeline string, overages *bool) error {
 	prefix := "/v1"
 	if c.client.Org != "" {
 		prefix = "/v1/organizations/" + c.client.Org
@@ -82,7 +83,7 @@ func (c *SubscriptionClient) Update(plan, timeline string, overages *bool) error
 		return fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	r, err := c.client.Post(prefix+"/subscription", body)
+	r, err := c.client.Post(ctx, prefix+"/subscription", body)
 	if err != nil {
 		return fmt.Errorf("failed to set organization plan: %w", err)
 	}

--- a/token.go
+++ b/token.go
@@ -1,0 +1,46 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type TokensClient client
+
+func (c *TokensClient) Validate(token string) (int64, error) {
+	r, err := c.client.Get("/v1/auth/validate", nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to request validation: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("failed to validate token: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct{ Exp int64 }](r)
+	if err != nil {
+		return 0, fmt.Errorf("failed to deserialize validate token response: %w", err)
+	}
+
+	return data.Exp, nil
+}
+
+func (c *TokensClient) Invalidate() (int64, error) {
+	r, err := c.client.Post("/v1/auth/invalidate", nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to request invalidation: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("failed to invalidate sessions: %w", parseResponseError(r))
+	}
+
+	data, err := unmarshal[struct{ ValidFrom int64 }](r)
+	if err != nil {
+		return 0, fmt.Errorf("failed to deserialize invalidate sessions response: %w", err)
+	}
+
+	return data.ValidFrom, nil
+}

--- a/token.go
+++ b/token.go
@@ -1,14 +1,15 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
 
 type TokensClient client
 
-func (c *TokensClient) Validate(token string) (int64, error) {
-	r, err := c.client.Get("/v1/auth/validate", nil)
+func (c *TokensClient) Validate(ctx context.Context, token string) (int64, error) {
+	r, err := c.client.Get(ctx, "/v1/auth/validate", nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to request validation: %s", err)
 	}
@@ -26,8 +27,8 @@ func (c *TokensClient) Validate(token string) (int64, error) {
 	return data.Exp, nil
 }
 
-func (c *TokensClient) Invalidate() (int64, error) {
-	r, err := c.client.Post("/v1/auth/invalidate", nil)
+func (c *TokensClient) Invalidate(ctx context.Context) (int64, error) {
+	r, err := c.client.Post(ctx, "/v1/auth/invalidate", nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to request invalidation: %s", err)
 	}

--- a/users.go
+++ b/users.go
@@ -1,0 +1,36 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type UsersClient client
+
+type UserInfo struct {
+	Username string `json:"username"`
+	Plan     string `json:"plan"`
+}
+
+type UserInfoResponse struct {
+	User UserInfo `json:"user"`
+}
+
+func (u *UsersClient) GetUser() (UserInfo, error) {
+	res, err := u.client.Get("/v1/current-user", nil)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("failed to get user info: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return UserInfo{}, parseResponseError(res)
+	}
+
+	data, err := unmarshal[UserInfoResponse](res)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	return data.User, nil
+}

--- a/users.go
+++ b/users.go
@@ -17,8 +17,8 @@ type UserInfoResponse struct {
 	User UserInfo `json:"user"`
 }
 
-func (u *UsersClient) GetUser(ctx context.Context) (UserInfo, error) {
-	res, err := u.client.Get(ctx, "/v1/current-user", nil)
+func (c *UsersClient) GetUser(ctx context.Context) (UserInfo, error) {
+	res, err := c.client.Get(ctx, "/v1/current-user", nil)
 	if err != nil {
 		return UserInfo{}, fmt.Errorf("failed to get user info: %s", err)
 	}

--- a/users.go
+++ b/users.go
@@ -1,6 +1,7 @@
 package turso
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -16,8 +17,8 @@ type UserInfoResponse struct {
 	User UserInfo `json:"user"`
 }
 
-func (u *UsersClient) GetUser() (UserInfo, error) {
-	res, err := u.client.Get("/v1/current-user", nil)
+func (u *UsersClient) GetUser(ctx context.Context) (UserInfo, error) {
+	res, err := u.client.Get(ctx, "/v1/current-user", nil)
 	if err != nil {
 		return UserInfo{}, fmt.Errorf("failed to get user info: %s", err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,33 @@
+package turso
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func unmarshal[T any](r *http.Response) (T, error) {
+	d, err := io.ReadAll(r.Body)
+	t := new(T)
+	if err != nil {
+		return *t, err
+	}
+	err = json.Unmarshal(d, &t)
+	return *t, err
+}
+
+func marshal(data interface{}) (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	err := json.NewEncoder(buf).Encode(data)
+	return buf, err
+}
+
+func parseResponseError(res *http.Response) error {
+	type ErrorResponse struct{ Error interface{} }
+	if result, err := unmarshal[ErrorResponse](res); err == nil {
+		return fmt.Errorf("%s", result.Error)
+	}
+	return fmt.Errorf("response failed with status %s", res.Status)
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,0 @@
-package turso
-
-const Version = "v0.1.0"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package turso
+
+const Version = "v0.1.0"


### PR DESCRIPTION
# Overview
This initial pull request is mainly just a port of the internal "SDK" used by the turso-cli [here](https://github.com/tursodatabase/turso-cli/tree/main/internal/turso). I did make a few changes to improve the developer flexibility from the get-go:
- Configurable baseUrl with default of the Turso Platform API hostname
- Configurable `*http.Client`
- Required context in all methods
- Standardized a lot of the variable names